### PR TITLE
hotfix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ VIENNA          = /home/Vienna_1.6
 ###############################################################
 
 
-CXXFLAGS        = -O4 -Wall -g -I$(VIENNA)/include/ViennaRNA 
+CXXFLAGS        = -O4 -Wall -g -fopenmp -I$(VIENNA)/include/ViennaRNA -I$(VIENNA)/include 
 LDFLAGS         = -L$(VIENNA)/lib -lRNA 
 CXX     	= g++
 

--- a/inv_folding_const.cpp
+++ b/inv_folding_const.cpp
@@ -151,7 +151,7 @@ void usage_help(char* name)
    cout << " \t\t local search. It is set to 0.1 by default.\n";
    cout << endl;
 
-   exit(1);
+   exit(0);
 }
 
 
@@ -223,7 +223,7 @@ int main(int argc, char *argv[])
    if ((argv[1][0] == '-') && (argv[1][1] == 'h'))
    {
       usage_help(argv[0]);
-      exit(1);
+      exit(0);
    }
    else
       brackets = argv[1];


### PR DESCRIPTION
modified exit code for help argument to 0, and modified the Makefile to include an additional include directory, and the fopenmp flag
